### PR TITLE
Git to ignore "parser" binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 parser
+main
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-main
+parser
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
This PR add "parser" (the compiled binary) to .gitignore and remove "main" as it is the default binary built when "go build" is executed.