### PR TITLE
Update devfile/api dependency to pick up change to v1alpha2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/parser
 go 1.14
 
 require (
-	github.com/devfile/kubernetes-api v0.0.0-20200721203247-1ae49a1fac4c
+	github.com/devfile/api v0.0.0-20200826170839-778718f72ad7
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
-github.com/devfile/kubernetes-api v0.0.0-20200721203247-1ae49a1fac4c h1:dW6x8CA7Qzmk9BRXzqv34U9pi9u+7zd5rWxT352FgCI=
-github.com/devfile/kubernetes-api v0.0.0-20200721203247-1ae49a1fac4c/go.mod h1:yqOXWQYZvwWrGU+M2bbMPkYobKw67ejseWTNdaKEPGA=
+github.com/devfile/api v0.0.0-20200826170839-778718f72ad7 h1:Pyy/lgsImhTbPf4JJ3MoX1+NWvl8rsgv0g/hrusDyfk=
+github.com/devfile/api v0.0.0-20200826170839-778718f72ad7/go.mod h1:TxJXWHjwATjDSGdheFL+iI/Sk533HuwsDA3nVBQa8c8=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -423,6 +423,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
@@ -556,6 +557,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/devfile/parser/data/2.0.0/components.go
+++ b/pkg/devfile/parser/data/2.0.0/components.go
@@ -3,7 +3,7 @@ package version200
 import (
 	"strings"
 
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/devfile/parser/data/2.0.0/components_test.go
+++ b/pkg/devfile/parser/data/2.0.0/components_test.go
@@ -3,7 +3,7 @@ package version200
 import (
 	"testing"
 
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 )
 
 func TestGetCommands(t *testing.T) {

--- a/pkg/devfile/parser/data/2.0.0/types.go
+++ b/pkg/devfile/parser/data/2.0.0/types.go
@@ -1,7 +1,7 @@
 package version200
 
 import (
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/devfile/parser/data/2.1.0/components.go
+++ b/pkg/devfile/parser/data/2.1.0/components.go
@@ -3,7 +3,7 @@ package version210
 import (
 	"strings"
 
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/devfile/parser/data/2.1.0/components_test.go
+++ b/pkg/devfile/parser/data/2.1.0/components_test.go
@@ -3,7 +3,7 @@ package version210
 import (
 	"testing"
 
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 )
 
 func TestGetCommands(t *testing.T) {

--- a/pkg/devfile/parser/data/2.1.0/types.go
+++ b/pkg/devfile/parser/data/2.1.0/types.go
@@ -1,7 +1,7 @@
 package version210
 
 import (
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/devfile/parser/data/common/types.go
+++ b/pkg/devfile/parser/data/common/types.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 )
 
 // DevfileMetadata metadata for devfile

--- a/pkg/devfile/parser/data/interface.go
+++ b/pkg/devfile/parser/data/interface.go
@@ -1,7 +1,7 @@
 package data
 
 import (
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/devfile/validate/components.go
+++ b/pkg/devfile/validate/components.go
@@ -3,7 +3,7 @@ package validate
 import (
 	"fmt"
 
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/devfile/validate/components_test.go
+++ b/pkg/devfile/validate/components_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
 

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -1,7 +1,7 @@
 package testingutil
 
 import (
-	v1 "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/parser/pkg/devfile/parser/data/common"
 	// versionsCommon "github.com/devfile/parser/pkg/devfile/parser/data/common"
 )
@@ -67,8 +67,8 @@ func (d TestDevfileData) GetProjects() []v1.Project {
 		ProjectSource: v1.ProjectSource{
 			Git: &v1.GitProjectSource{
 				GitLikeProjectSource: v1.GitLikeProjectSource{
-					CommonProjectSource: v1.CommonProjectSource{
-						Location: sourceLocation[0],
+					Remotes: map[string]string{
+						"origin": sourceLocation[0],
 					},
 				},
 			},
@@ -81,8 +81,8 @@ func (d TestDevfileData) GetProjects() []v1.Project {
 		ProjectSource: v1.ProjectSource{
 			Git: &v1.GitProjectSource{
 				GitLikeProjectSource: v1.GitLikeProjectSource{
-					CommonProjectSource: v1.CommonProjectSource{
-						Location: sourceLocation[1],
+					Remotes: map[string]string{
+						"origin": sourceLocation[1],
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?
Updates the dependency on `devfile/api` to (at the time of writing) the current HEAD, picking up [changes](https://github.com/devfile/api/compare/1ae49a1fac4c..778718f72ad7d119be11eb2632b23cb5927be29e) in the devfile api -- notably:
- `devfile/api` has dropped the `v1alpha1` version in favor of `v1alpha2`
- A minor incompatibility in the project spec.

The two devfile/api PRs that impact this PR are
1. https://github.com/devfile/api/pull/120 - change representation of git project in devfile spec
2. https://github.com/devfile/api/pull/125 - switch to v1alpha2 version to allow breaking changes from v1alpha1

### What issues does this PR fix or reference?
Related to https://github.com/devfile/parser/issues/26

### Is your PR tested? Consider putting some instruction how to test your changes
I ran `make test` but am unfamiliar with the repo otherwise.